### PR TITLE
Iotc paad

### DIFF
--- a/.azure-devops/sync_models.yml
+++ b/.azure-devops/sync_models.yml
@@ -2,7 +2,7 @@
 
 variables:
  - name: dmrClientVer
-   value: 1.0.0-beta.2
+   value: 1.0.0-beta.3
  - name: indexStagingPath
    value: ./index_pages/
  - name: pageLimit

--- a/.github/workflows/validate_models.yml
+++ b/.github/workflows/validate_models.yml
@@ -13,13 +13,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Azure/iot-plugandplay-models-tools
-          ref: 1.0.0-beta.2
+          ref: 1.0.0-beta.3
           path: dmr-tool-cache
 
       - name: Build and install Microsoft.IoT.ModelsRepository.CommandLine tool (dmr-client)
         run: |
           dotnet pack dmr-tool-cache/clients/dotnet -v q -c Release
-          dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --add-source dmr-tool-cache/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/bin/Release --version 1.0.0-beta.2
+          dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --add-source dmr-tool-cache/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/bin/Release --version 1.0.0-beta.3
           rm -rf dmr-tool-cache
 
       - name: Checkout code

--- a/dtmi/azure/sensors-1.json
+++ b/dtmi/azure/sensors-1.json
@@ -69,7 +69,7 @@
           "en": "Location"
         },
         "name": "geolocation",
-        "schema": "point"
+        "schema": "geopoint"
       }
     ],
     "displayName": {

--- a/dtmi/azure/sensors-1.json
+++ b/dtmi/azure/sensors-1.json
@@ -1,0 +1,78 @@
+{
+    "@context": [
+      "dtmi:iotcentral:context;2",
+      "dtmi:dtdl:context;2"
+    ],
+    "@id": "dtmi:azure:sensors;1",
+    "@type": "Interface",
+    "contents": [
+      {
+        "@id": "dtmi:azure:sensors:battery;1",
+        "@type": "Telemetry",
+        "comment": "Level percentage",
+        "displayName": {
+          "en": "Battery Level"
+        },
+        "name": "battery",
+        "schema": "integer"
+      },
+      {
+        "@id": "dtmi:azure:sensors:accelerometer;1",
+        "@type": [
+          "Telemetry",
+          "AccelerationVector"
+        ],
+        "displayName": {
+          "en": "Acceleration"
+        },
+        "name": "accelerometer",
+        "schema": "vector"
+      },
+      {
+        "@id": "dtmi:azure:sensors:gyroscope;1",
+        "@type": "Telemetry",
+        "displayName": {
+          "en": "Rotation"
+        },
+        "name": "gyroscope",
+        "schema": "vector"
+      },
+      {
+        "@id": "dtmi:azure:sensors:magnetometer;1",
+        "@type": "Telemetry",
+        "displayName": {
+          "en": "Magnetic induction"
+        },
+        "name": "magnetometer",
+        "schema": "vector"
+      },
+      {
+        "@id": "dtmi:azure:sensors:barometer;1",
+        "@type": [
+          "Telemetry",
+          "Pressure"
+        ],
+        "displayName": {
+          "en": "Pressure"
+        },
+        "name": "barometer",
+        "schema": "double",
+        "unit": "kilopascal"
+      },
+      {
+        "@id": "dtmi:azure:sensors:geolocation;1",
+        "@type": [
+          "Telemetry",
+          "Location"
+        ],
+        "displayName": {
+          "en": "Location"
+        },
+        "name": "geolocation",
+        "schema": "point"
+      }
+    ],
+    "displayName": {
+      "en": "Sensors"
+    }
+  }

--- a/dtmi/azure/smartphone-1.json
+++ b/dtmi/azure/smartphone-1.json
@@ -1,0 +1,351 @@
+{
+    "@id": "dtmi:azure:smartphone;1",
+    "@type": "Interface",
+    "contents": [
+      {
+        "@id": "dtmi:azure:smartphone:sensors;1",
+        "@type": "Component",
+        "displayName": {
+          "en": "Sensors"
+        },
+        "name": "sensors",
+        "schema": "dtmi:azure:sensors;1"
+      },
+      {
+        "@id": "dtmi:azure:smartphone:device_info;1",
+        "@type": "Component",
+        "displayName": {
+          "en": "Device information"
+        },
+        "name": "device_info",
+        "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
+      },
+      {
+        "@id": "dtmi:azure:smartphone:enableSensors;1",
+        "@type": "Command",
+        "commandType": "synchronous",
+        "displayName": {
+          "en": "Enable Sensors"
+        },
+        "name": "enableSensors",
+        "request": {
+          "@type": "CommandPayload",
+          "displayName": {
+            "en": "Sensor"
+          },
+          "name": "sensor",
+          "schema": {
+            "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema;1",
+            "@type": "Object",
+            "displayName": {
+              "en": "Sensor"
+            },
+            "fields": [
+              {
+                "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor;1",
+                "displayName": {
+                  "en": "Sensor"
+                },
+                "name": "sensor",
+                "schema": {
+                  "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor:schema;1",
+                  "@type": "Enum",
+                  "displayName": {
+                    "en": "Enum"
+                  },
+                  "enumValues": [
+                    {
+                      "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor:schema:Acceleration;1",
+                      "displayName": {
+                        "en": "Acceleration"
+                      },
+                      "enumValue": "accelerometer",
+                      "name": "Acceleration"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor:schema:Pressure;1",
+                      "displayName": {
+                        "en": "Pressure"
+                      },
+                      "enumValue": "barometer",
+                      "name": "Pressure"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor:schema:Rotation;1",
+                      "displayName": {
+                        "en": "Rotation"
+                      },
+                      "enumValue": "gyroscope",
+                      "name": "Rotation"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor:schema:MagneticInduction;1",
+                      "displayName": {
+                        "en": "Magnetic Induction"
+                      },
+                      "enumValue": "magnetometer",
+                      "name": "MagneticInduction"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor:schema:Location;1",
+                      "displayName": {
+                        "en": "Location"
+                      },
+                      "enumValue": "geolocation",
+                      "name": "Location"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:sensor:schema:Battery;1",
+                      "displayName": {
+                        "en": "Battery Level"
+                      },
+                      "enumValue": "battery",
+                      "name": "Battery"
+                    }
+                  ],
+                  "valueSchema": "string"
+                }
+              },
+              {
+                "@id": "dtmi:azure:smartphone:enableSensors:request:payload:schema:enable;1",
+                "displayName": {
+                  "en": "Enable"
+                },
+                "name": "enable",
+                "schema": "boolean"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "@id": "dtmi:azure:smartphone:changeInterval;1",
+        "@type": "Command",
+        "commandType": "synchronous",
+        "displayName": {
+          "en": "Change Delivery Interval"
+        },
+        "name": "changeInterval",
+        "request": {
+          "@type": "CommandPayload",
+          "displayName": {
+            "en": "Payload"
+          },
+          "name": "payload",
+          "schema": {
+            "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema;1",
+            "@type": "Object",
+            "displayName": {
+              "en": "Sensor"
+            },
+            "fields": [
+              {
+                "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor;1",
+                "displayName": {
+                  "en": "Sensor"
+                },
+                "name": "sensor",
+                "schema": {
+                  "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor:schema;1",
+                  "@type": "Enum",
+                  "displayName": {
+                    "en": "Enum"
+                  },
+                  "enumValues": [
+                    {
+                      "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor:schema:Acceleration;1",
+                      "displayName": {
+                        "en": "Acceleration"
+                      },
+                      "enumValue": "accelerometer",
+                      "name": "Acceleration"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor:schema:Pressure;1",
+                      "displayName": {
+                        "en": "Pressure"
+                      },
+                      "enumValue": "barometer",
+                      "name": "Pressure"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor:schema:Rotation;1",
+                      "displayName": {
+                        "en": "Rotation"
+                      },
+                      "enumValue": "gyroscope",
+                      "name": "Rotation"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor:schema:MagneticInduction;1",
+                      "displayName": {
+                        "en": "Magnetic Induction"
+                      },
+                      "enumValue": "magnetometer",
+                      "name": "MagneticInduction"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor:schema:Location;1",
+                      "displayName": {
+                        "en": "Location"
+                      },
+                      "enumValue": "geolocation",
+                      "name": "Location"
+                    },
+                    {
+                      "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:sensor:schema:Battery;1",
+                      "displayName": {
+                        "en": "Battery Level"
+                      },
+                      "enumValue": "battery",
+                      "name": "Battery"
+                    }
+                  ],
+                  "valueSchema": "string"
+                }
+              },
+              {
+                "@id": "dtmi:azure:smartphone:changeInterval:request:payload:schema:interval;1",
+                "displayName": {
+                  "en": "Interval"
+                },
+                "name": "interval",
+                "schema": "integer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "@id": "dtmi:azure:smartphone:lightOn;1",
+        "@type": "Command",
+        "commandType": "synchronous",
+        "displayName": {
+          "en": "LightOn"
+        },
+        "name": "lightOn",
+        "request": {
+          "@type": "CommandPayload",
+          "displayName": {
+            "en": "Parameters"
+          },
+          "name": "parameters",
+          "schema": {
+            "@type": "Object",
+            "displayName": {
+              "en": "Object"
+            },
+            "fields": [
+              {
+                "displayName": {
+                  "en": "Duration"
+                },
+                "name": "duration",
+                "schema": "integer"
+              },
+              {
+                "displayName": {
+                  "en": "Pulses interval"
+                },
+                "name": "delay",
+                "schema": "integer"
+              },
+              {
+                "displayName": {
+                  "en": "Pulses"
+                },
+                "name": "pulses",
+                "schema": "integer"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "@id": "dtmi:azure:smartphone:writeableProp;1",
+        "@type": "Property",
+        "displayName": {
+          "en": "Writeable Property"
+        },
+        "name": "writeableProp",
+        "schema": "string",
+        "writable": true
+      },
+      {
+        "@id": "dtmi:azure:smartphone:readOnlyProp;1",
+        "@type": "Property",
+        "displayName": {
+          "en": "Readonly Property"
+        },
+        "name": "readOnlyProp",
+        "schema": "string"
+      }
+    ],
+    "displayName": {
+      "en": "Smartphone"
+    },
+    "schemas": [
+      {
+        "@id": "dtmi:azure:sensors:schema;1",
+        "@type": "Enum",
+        "displayName": {
+          "en": "Enum"
+        },
+        "enumValues": [
+          {
+            "@id": "dtmi:azure:sensors:schema:Acceleration;1",
+            "displayName": {
+              "en": "Acceleration"
+            },
+            "enumValue": "accelerometer",
+            "name": "Acceleration"
+          },
+          {
+            "@id": "dtmi:azure:sensors:schema:Pressure;1",
+            "displayName": {
+              "en": "Pressure"
+            },
+            "enumValue": "barometer",
+            "name": "Pressure"
+          },
+          {
+            "@id": "dtmi:azure:sensors:schema:Rotation;1",
+            "displayName": {
+              "en": "Rotation"
+            },
+            "enumValue": "gyroscope",
+            "name": "Rotation"
+          },
+          {
+            "@id": "dtmi:azure:sensors:schema:MagneticInduction;1",
+            "displayName": {
+              "en": "Magnetic Induction"
+            },
+            "enumValue": "magnetometer",
+            "name": "MagneticInduction"
+          },
+          {
+            "@id": "dtmi:azure:sensors:schema:Location;1",
+            "displayName": {
+              "en": "Location"
+            },
+            "enumValue": "geolocation",
+            "name": "Location"
+          },
+          {
+            "@id": "dtmi:azure:sensors:schema:Battery;1",
+            "displayName": {
+              "en": "Battery Level"
+            },
+            "enumValue": "battery",
+            "name": "Battery"
+          }
+        ],
+        "valueSchema": "string"
+      }
+    ],
+    "@context": [
+      "dtmi:iotcentral:context;2",
+      "dtmi:dtdl:context;2"
+    ]
+  }

--- a/dtmi/azure/smartphone-1.json
+++ b/dtmi/azure/smartphone-1.json
@@ -286,14 +286,14 @@
     },
     "schemas": [
       {
-        "@id": "dtmi:azure:sensors:schema;1",
+        "@id": "dtmi:azure:smartphone:sensors:schema;1",
         "@type": "Enum",
         "displayName": {
           "en": "Enum"
         },
         "enumValues": [
           {
-            "@id": "dtmi:azure:sensors:schema:Acceleration;1",
+            "@id": "dtmi:azure:smartphone:sensors:schema:Acceleration;1",
             "displayName": {
               "en": "Acceleration"
             },
@@ -301,7 +301,7 @@
             "name": "Acceleration"
           },
           {
-            "@id": "dtmi:azure:sensors:schema:Pressure;1",
+            "@id": "dtmi:azure:smartphone:sensors:schema:Pressure;1",
             "displayName": {
               "en": "Pressure"
             },
@@ -309,7 +309,7 @@
             "name": "Pressure"
           },
           {
-            "@id": "dtmi:azure:sensors:schema:Rotation;1",
+            "@id": "dtmi:azure:smartphone:sensors:schema:Rotation;1",
             "displayName": {
               "en": "Rotation"
             },
@@ -317,7 +317,7 @@
             "name": "Rotation"
           },
           {
-            "@id": "dtmi:azure:sensors:schema:MagneticInduction;1",
+            "@id": "dtmi:azure:smartphone:sensors:schema:MagneticInduction;1",
             "displayName": {
               "en": "Magnetic Induction"
             },
@@ -325,7 +325,7 @@
             "name": "MagneticInduction"
           },
           {
-            "@id": "dtmi:azure:sensors:schema:Location;1",
+            "@id": "dtmi:azure:smartphone:sensors:schema:Location;1",
             "displayName": {
               "en": "Location"
             },
@@ -333,7 +333,7 @@
             "name": "Location"
           },
           {
-            "@id": "dtmi:azure:sensors:schema:Battery;1",
+            "@id": "dtmi:azure:smartphone:sensors:schema:Battery;1",
             "displayName": {
               "en": "Battery Level"
             },


### PR DESCRIPTION
### Thank you for contributing to the Azure IoT Plug and Play Models repository

This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

The repository pipeline will ensure minimum validation of incoming DTDL models.  

- PR validation steps are described in the tools [Wiki](https://github.com/Azure/iot-plugandplay-models-tools/wiki/Validation-Pipeline#pr-validation-checks).
- The same validation can be run locally via the [dmr-client](https://github.com/Azure/iot-plugandplay-models-tools/tree/dev/clients/dotnet#device-model-repository-client) CLI.

## Requested info template for model(s) submission

When submitting models to the repository we ask that you provide as much of the following meta information around your models and related devices as possible. This info will be used to improve Plug and Play.

:star2: Please replace the markdown comment examples with your own values.

### Company Info

<!--
> Info identifying your company (if applicable).

Examples:
- Company name
- Company website
- GitHub presence
- Other

-->

### IoT Plug and Play Device Info

<!--
> Info identifying your PnP device.

Examples:
- Product website
- OS & Arch
- SDK used for model implementation
- Other

-->

### Model Submission Goals

<!--
> Info related to broader PnP goals.  

Examples:
- Device certification
- Presence in the [Certified Device catalog](https://devicecatalog.azure.com/)
- IoT Central integration
- Custom solution
- Other

-->

### Code Owners & Reserved Names

<!--
> Indicates GitHub alias entries to be added to the repo `CODEOWNERS` for the incoming model namespace. The codeowner is expected to be involved in subsequent DTDL model submissions against the same namespace.

If no alias is specified then we assume the PR submitter is responsible for the namespace.

Examples:
- @ContosoModelNamespaceOwner 1

-->
